### PR TITLE
Log environment variable keys and not their contents

### DIFF
--- a/src/serverless-ssm-fetch.js
+++ b/src/serverless-ssm-fetch.js
@@ -147,7 +147,7 @@ class SsmFetch {
 
       }
 
-      this.serverless.cli.log('> serverless-ssm-fetch: Function "' + functionName + '" set environment variables: ' + JSON.stringify(currentFunction.environment));
+      this.serverless.cli.log('> serverless-ssm-fetch: Function "' + functionName + '" set environment variables: ' + JSON.stringify(Object.keys(currentFunction.environment)));
 
     });
 


### PR DESCRIPTION
Please consider only logging the keys of the environment variables that are being set and not their actual contents. This prevents leakage of sensitive data in CI build processes.