### PR TITLE
Hide sensitive data on deploy

### DIFF
--- a/dist/serverless-ssm-fetch.js
+++ b/dist/serverless-ssm-fetch.js
@@ -109,7 +109,7 @@ var SsmFetch = function () {
         // Triggers all `getParameter` queries concurrently
         Promise.all(promiseCollection).then(function (success) {
           _this2.serverless.cli.log('> serverless-ssm-fetch: Get parameters success. Fetched SSM parameters:');
-          _this2.serverless.cli.log(JSON.stringify(_this2.serverless.variables.serverlessSsmFetch));
+          _this2.serverless.cli.log(JSON.stringify(Object.keys(_this2.serverless.variables.serverlessSsmFetch)));
           return resolve(success);
         }).catch(function (error) {
           _this2.serverless.cli.log('> serverless-ssm-fetch: Get parameter: ERROR');

--- a/src/serverless-ssm-fetch.js
+++ b/src/serverless-ssm-fetch.js
@@ -95,7 +95,7 @@ class SsmFetch {
       Promise.all(promiseCollection)
           .then((success) => {
             this.serverless.cli.log('> serverless-ssm-fetch: Get parameters success. Fetched SSM parameters:');
-            this.serverless.cli.log(JSON.stringify(this.serverless.variables.serverlessSsmFetch));
+            this.serverless.cli.log(JSON.stringify(Object.keys(this.serverless.variables.serverlessSsmFetch)));
             return resolve(success);
           })
           .catch((error) => {


### PR DESCRIPTION
Similar to https://github.com/gozup/serverless-ssm-fetch/pull/2/files, the fetched values should not be logged.